### PR TITLE
Decode Entity Appearance into readable struct and enum

### DIFF
--- a/Source/DISRuntime/Private/DISGameManager.cpp
+++ b/Source/DISRuntime/Private/DISGameManager.cpp
@@ -161,7 +161,7 @@ void ADISGameManager::HandleEntityStatePDU(FEntityStatePDU EntityStatePDUIn)
 		else
 		{
 			//Check if the entity has been deactivated -- Entity is deactivated if the 23rd bit of the Entity Appearance value is set
-			if (EntityStatePDUIn.EntityAppearance & (1 << 23))
+			if (EntityStatePDUIn.EntityAppearance.IsDeactivated)
 			{
 				UE_LOG(LogDISGameManager, Log, TEXT("Received Entity State PDU with a Deactivated Entity Appearance for an entity that is not in the level. Ignoring the PDU. Entity marking: %s"), *EntityStatePDUIn.Marking);
 				return;

--- a/Source/DISRuntime/Private/DISReceiveComponent.cpp
+++ b/Source/DISRuntime/Private/DISReceiveComponent.cpp
@@ -58,7 +58,7 @@ void UDISReceiveComponent::TickComponent(float DeltaTime, ELevelTick TickType, F
 void UDISReceiveComponent::HandleEntityStatePDU(FEntityStatePDU NewEntityStatePDU)
 {
 	//Check if the entity has been deactivated -- Entity is deactivated if the 23rd bit of the Entity Appearance value is set
-	if (NewEntityStatePDU.EntityAppearance & (1 << 23))
+	if (NewEntityStatePDU.EntityAppearance.IsDeactivated)
 	{
 		UE_LOG(LogDISReceiveComponent, Log, TEXT("%s Entity Appearance is set to deactivated, deleting entity..."), *NewEntityStatePDU.Marking);
 		GetOwner()->Destroy();
@@ -82,7 +82,7 @@ void UDISReceiveComponent::HandleEntityStatePDU(FEntityStatePDU NewEntityStatePD
 void UDISReceiveComponent::HandleEntityStateUpdatePDU(FEntityStateUpdatePDU NewEntityStateUpdatePDU)
 {
 	//Check if the entity has been deactivated -- Entity is deactivated if the 23rd bit of the Entity Appearance value is set
-	if (NewEntityStateUpdatePDU.EntityAppearance & (1 << 23))
+	if (NewEntityStateUpdatePDU.EntityAppearance.IsDeactivated)
 	{
 		UE_LOG(LogDISReceiveComponent, Log, TEXT("%s Entity Appearance is set to deactivated, deleting entity..."), *NewEntityStateUpdatePDU.EntityID.ToString());
 		GetOwner()->Destroy();

--- a/Source/DISRuntime/Private/DISSendComponent.cpp
+++ b/Source/DISRuntime/Private/DISSendComponent.cpp
@@ -92,7 +92,7 @@ void UDISSendComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 	finalESPDU.EntityType = EntityType;
 	finalESPDU.ForceID = EntityForceID;
 	finalESPDU.Marking = EntityMarking;
-	finalESPDU.EntityAppearance |= 1 << 23;
+	finalESPDU.EntityAppearance.IsDeactivated = true;
 
 	if (IsValid(DISGameManager))
 	{

--- a/Source/DISRuntime/Private/DeadReckoning_BPFL.cpp
+++ b/Source/DISRuntime/Private/DeadReckoning_BPFL.cpp
@@ -375,7 +375,7 @@ bool UDeadReckoning_BPFL::DeadReckoning(FEntityStatePDU EntityPDUToDeadReckon, f
 	bool bSupported = true;
 
 	//If the entity is frozen, don't update dead reckoning
-	if (EntityPDUToDeadReckon.EntityAppearance & (1 << 21))
+	if (EntityPDUToDeadReckon.EntityAppearance.IsFrozen)
 	{
 		return false;
 	}

--- a/Source/DISRuntime/Public/DISEnumsAndStructs.h
+++ b/Source/DISRuntime/Public/DISEnumsAndStructs.h
@@ -858,3 +858,109 @@ struct FDeadReckoningParameters
 		return OutParam;
 	}
 };
+
+UENUM(BlueprintType)
+enum class EEntityDamage : uint8
+{
+	NoDamage,
+	SlightDamage,
+	ModerateDamage,
+	Destroyed
+};
+
+USTRUCT(BlueprintType)
+struct FEntityAppearance
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool PaintScheme = false;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool MobilityKilled = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool FirePowerKilled = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		EEntityDamage Damage = EEntityDamage::NoDamage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool IsSmoking = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool IsEngineSmoking = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		int Trailing = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		int HatchState = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool LightPrimary = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool LightSecondary = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool LightCollision = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool IsFlaming = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool IsFrozen = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool IsDeactivated = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs")
+		bool IsLandingGearExtended = false;
+
+	int32 RawVal = 0;
+
+	FEntityAppearance() {}
+
+	FEntityAppearance(uint32 val)
+		: RawVal(val)
+	{
+		PaintScheme = (val & (0b1 << 0) >> 0);
+		MobilityKilled = (val & (0b1 << 1) >> 1);
+		FirePowerKilled = (val & (0b1 << 2) >> 2);
+		Damage = static_cast<EEntityDamage>((val & (0b11 << 3)) >> 3);
+		IsSmoking= (val & (0b1 << 5) >> 5);
+		IsEngineSmoking = (val & (0b1 << 6) >> 6);
+		Trailing = ((val & (0b11 << 7)) >> 7);
+		HatchState = ((val & (0b111 << 9)) >> 9);
+		LightPrimary = (val & (0b1 << 12) >> 12);
+		LightSecondary = (val & (0b1 << 13) >> 13);
+		LightCollision = (val & (0b1 << 14) >> 14);
+		IsFlaming = (val & (0b1 << 15) >> 15);
+
+		IsFrozen = (val & (0b1 << 21) >> 21);
+		IsDeactivated = (val & (0b1 << 23) >> 23);
+
+		IsLandingGearExtended = (val & (0b1 << 25) >> 25);
+	}
+
+	int32 UpdateValue()
+	{
+		RawVal |= PaintScheme << 0;
+		RawVal |= MobilityKilled << 1;
+		RawVal |= FirePowerKilled << 2;
+		RawVal |= int(Damage) << 3;
+		RawVal |= IsSmoking << 5;
+		RawVal |= IsEngineSmoking << 6;
+		RawVal |= Trailing << 7;
+		RawVal |= HatchState << 9;
+		RawVal |= LightPrimary << 12;
+		RawVal |= LightSecondary << 13;
+		RawVal |= LightCollision << 14;
+		RawVal |= IsFlaming << 15;
+		RawVal |= IsFrozen << 21;
+		RawVal |= IsDeactivated << 23;
+		RawVal |= IsLandingGearExtended << 25;
+		return RawVal;
+	}
+};

--- a/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStatePDU.h
+++ b/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStatePDU.h
@@ -39,7 +39,7 @@ struct FEntityStatePDU : public FEntityInformationFamilyPDU
 		FEntityType EntityType;
 	/** A series of enumerations used to describe the appearance of the entity according to SISO-REF-010-2015 UIDs 31-43. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs|PDUs|EntityState")
-		int32 EntityAppearance;
+		FEntityAppearance EntityAppearance;
 	/** A series of enumerations used to describe the capabilities of the entity according to SISO-REF-010-2015 UID 55. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs|PDUs|EntityState")
 		int32 Capabilities;
@@ -104,7 +104,7 @@ struct FEntityStatePDU : public FEntityInformationFamilyPDU
 		ForceID = static_cast<EForceID>(EntityStatePDUIn->getForceId());
 		Marking = FString(EntityStatePDUIn->getMarking().getCharacters());
 		Marking.LeftInline(11);
-		EntityAppearance = EntityStatePDUIn->getEntityAppearance();
+		EntityAppearance = FEntityAppearance(EntityStatePDUIn->getEntityAppearance());
 		Capabilities = EntityStatePDUIn->getCapabilities();
 
 		//Entity type
@@ -164,7 +164,7 @@ struct FEntityStatePDU : public FEntityInformationFamilyPDU
 		OutOrientation.setPhi(EntityOrientation.Roll);
 		EntityStatePDUOut.setEntityOrientation(OutOrientation);
 
-		EntityStatePDUOut.setEntityAppearance(EntityAppearance);
+		EntityStatePDUOut.setEntityAppearance(EntityAppearance.UpdateValue());
 		EntityStatePDUOut.setDeadReckoningParameters(DeadReckoningParameters.ToOpenDIS());
 
 		DIS::Marking OutMarking;

--- a/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStateUpdatePDU.h
+++ b/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStateUpdatePDU.h
@@ -27,7 +27,7 @@ struct FEntityStateUpdatePDU : public FEntityInformationFamilyPDU
 		FVector EntityLinearVelocity;
 	/** A series of enumerations used to describe the appearance of the entity according to SISO-REF-010-2015 UIDs 31-43. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|Structs|PDUs|EntityStateUpdate")
-		int32 EntityAppearance;
+		FEntityAppearance EntityAppearance;
 	/** An 8 bit field of unused padding */
 	UPROPERTY()
 		int32 Padding1;
@@ -75,7 +75,7 @@ struct FEntityStateUpdatePDU : public FEntityInformationFamilyPDU
 
 		//Single Vars
 		Padding1 = EntityStateUpdatePDUIn->getPadding1();
-		EntityAppearance = EntityStateUpdatePDUIn->getEntityAppearance();
+		EntityAppearance = FEntityAppearance(EntityStateUpdatePDUIn->getEntityAppearance());
 
 		//Articulation Parameters
 		for (int i = 0; i < EntityStateUpdatePDUIn->getNumberOfArticulationParameters(); i++)
@@ -126,7 +126,7 @@ struct FEntityStateUpdatePDU : public FEntityInformationFamilyPDU
 		OutOrientation.setPhi(EntityOrientation.Roll);
 		EntityStateUpdatePDUOut.setEntityOrientation(OutOrientation);
 
-		EntityStateUpdatePDUOut.setEntityAppearance(EntityAppearance);
+		EntityStateUpdatePDUOut.setEntityAppearance(EntityAppearance.UpdateValue());
 
 		std::vector<DIS::ArticulationParameter> OutArtParams;
 		for (FArticulationParameters ArticulationParameter : ArticulationParameters)


### PR DESCRIPTION
The Entity State Appearance bitfield is read into a more user friendly struct with bools and enums.
This struct only implements the common fields, as this field is dependent on the domain.