### PR TITLE
Option to apply location and rotation to owning actor when receiving

### DIFF
--- a/Source/DISRuntime/Private/DISReceiveComponent.cpp
+++ b/Source/DISRuntime/Private/DISReceiveComponent.cpp
@@ -28,16 +28,20 @@ void UDISReceiveComponent::InitializeComponent()
 
 	if (IsValid(DISGameManager))
 	{
-		FInitialDISConditions initDISConditions = *DISGameManager->InitialEntityConditions.Find(GetOwner());
-		SpawnedFromNetwork = initDISConditions.SpawnedFromNetwork;
+		auto const* FoundInitConditions = DISGameManager->InitialEntityConditions.Find(GetOwner());
+		if (FoundInitConditions)
+		{
+			FInitialDISConditions initDISConditions = *FoundInitConditions;
+			SpawnedFromNetwork = initDISConditions.SpawnedFromNetwork;
 
-		UpdateCommonEntityStateInfo(initDISConditions.EntityStatePDU);
+			UpdateCommonEntityStateInfo(initDISConditions.EntityStatePDU);
 
-		EntityType = initDISConditions.EntityStatePDU.EntityType;
-		EntityForceID = initDISConditions.EntityStatePDU.ForceID;
-		EntityMarking = initDISConditions.EntityStatePDU.Marking;
+			EntityType = initDISConditions.EntityStatePDU.EntityType;
+			EntityForceID = initDISConditions.EntityStatePDU.ForceID;
+			EntityMarking = initDISConditions.EntityStatePDU.Marking;
 
-		DISGameManager->InitialEntityConditions.Remove(GetOwner());
+			DISGameManager->InitialEntityConditions.Remove(GetOwner());
+		}
 	}
 }
 
@@ -71,6 +75,7 @@ void UDISReceiveComponent::HandleEntityStatePDU(FEntityStatePDU NewEntityStatePD
 	EntityForceID = NewEntityStatePDU.ForceID;
 	EntityMarking = NewEntityStatePDU.Marking;
 
+	ApplyToOwnerIfActivated(NewEntityStatePDU);
 	OnReceivedEntityStatePDU.Broadcast(NewEntityStatePDU);
 
 	if (!PerformDeadReckoning)
@@ -121,6 +126,7 @@ void UDISReceiveComponent::UpdateCommonEntityStateInfo(FEntityStatePDU NewEntity
 	GetOwner()->SetLifeSpan(DISTimeoutSeconds);
 
 	NumberEntityStatePDUsReceived++;
+	ApplyToOwnerIfActivated(MostRecentDeadReckonedEntityStatePDU);
 }
 
 void UDISReceiveComponent::HandleFirePDU(FFirePDU FirePDUIn)
@@ -182,6 +188,7 @@ void UDISReceiveComponent::DoDeadReckoning(float DeltaTime)
 				MostRecentDeadReckonedEntityStatePDU = SmoothDeadReckoning(MostRecentDeadReckonedEntityStatePDU);
 			}
 
+			ApplyToOwnerIfActivated(MostRecentDeadReckonedEntityStatePDU);
 			OnDeadReckoningUpdate.Broadcast(MostRecentDeadReckonedEntityStatePDU);
 		}
 
@@ -238,6 +245,10 @@ void UDISReceiveComponent::GroundClamping_Implementation()
 			TArray<FTransform> allClampTransforms;
 			allClampTransforms.Add(clampTransform);
 
+			if (ApplyToOwner)
+			{
+				GetOwner()->SetActorLocationAndRotation(clampLocation, clampRotation);
+			}
 			OnGroundClampingUpdate.Broadcast(allClampTransforms);
 		}
 	}
@@ -254,4 +265,16 @@ FEntityStatePDU UDISReceiveComponent::SmoothDeadReckoning(FEntityStatePDU DeadRe
 	SmoothedDeadReckonPDU.EntityOrientation -= FMath::Lerp(EntityRotationDifference, FRotator(0, 0, 0), alpha);
 
 	return SmoothedDeadReckonPDU;
+}
+
+void UDISReceiveComponent::ApplyToOwnerIfActivated(FEntityStatePDU const& StatePDU)
+{
+	if (!ApplyToOwner)
+	{
+		return;
+	}
+	FVector newLocation;
+	FRotator newRotation;
+	UDIS_BPFL::GetUnrealLocationAndOrientationFromEntityStatePdu(StatePDU, GeoReferencingSystem, newLocation, newRotation);
+	GetOwner()->SetActorLocationAndRotation(newLocation, newRotation);
 }

--- a/Source/DISRuntime/Public/DISReceiveComponent.h
+++ b/Source/DISRuntime/Public/DISReceiveComponent.h
@@ -211,6 +211,11 @@ public:
 	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|DIS Receive Component|DIS Settings")
 		TEnumAsByte<ETraceTypeQuery> GoundClampingCollisionChannel = UEngineTypes::ConvertToTraceType(ECollisionChannel::ECC_Visibility);
+	/**
+	 * To automatically apply entity states to the owner actor.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GRILL DIS|DIS Receive Component|DIS Settings")
+		bool ApplyToOwner = false;
 
 protected:
 	// Called when the game starts
@@ -226,4 +231,5 @@ private:
 
 	void UpdateCommonEntityStateInfo(FEntityStatePDU NewEntityStatePDU);
 	FEntityStatePDU SmoothDeadReckoning(FEntityStatePDU DeadReckonPDUToSmooth);
+	void ApplyToOwnerIfActivated(FEntityStatePDU const& StatePDU);
 };


### PR DESCRIPTION
Add an option to the DISReceiver to automatically apply the location and rotation to the owning actor, allowing a more complete out-of-the-box experience.

This also prevents a null pointer when having DIS actors statically present in the scene.