### PR TITLE
Remove memory leak when receiving messages

### DIFF
--- a/Source/DISRuntime/Private/PDUProcessor.cpp
+++ b/Source/DISRuntime/Private/PDUProcessor.cpp
@@ -22,7 +22,7 @@ void UPDUProcessor::HandleOnReceivedUDPBytes(const TArray<uint8>& Bytes, const F
 	ProcessDISPacket(Bytes);
 }
 
-void UPDUProcessor::ProcessDISPacket(TArray<uint8> InData)
+void UPDUProcessor::ProcessDISPacket(const TArray<uint8>& InData)
 {
 	SCOPE_CYCLE_COUNTER(STAT_ProcessDISPacket);
 	int bytesArrayLength = InData.Num();
@@ -32,105 +32,96 @@ void UPDUProcessor::ProcessDISPacket(TArray<uint8> InData)
 		return;
 	}
 
-	EPDUType receivedPDUType = static_cast<EPDUType>(InData[PDU_TYPE_POSITION]);
+	const EPDUType receivedPDUType = static_cast<EPDUType>(InData[PDU_TYPE_POSITION]);
+
+	DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
 
 	//For list of enums for PDU type refer to SISO-REF-010-2015, ANNEX A
 	switch (receivedPDUType)
 	{
 	case EPDUType::EntityState:
 	{
-		DIS::EntityStatePdu* receivedESPDU = new DIS::EntityStatePdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedESPDU->unmarshal(ds);
+		DIS::EntityStatePdu receivedESPDU;
+		receivedESPDU.unmarshal(ds);
 
 		FEntityStatePDU entityStatePDU;
 		entityStatePDU.SetupFromOpenDIS(receivedESPDU);
 
 		OnEntityStatePDUProcessed.Broadcast(entityStatePDU);
 
-		break;
+		return;
 	}
 	case EPDUType::Fire:
 	{
-		DIS::FirePdu* receivedFirePDU = new DIS::FirePdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedFirePDU->unmarshal(ds);
+		DIS::FirePdu receivedFirePDU;
+		receivedFirePDU.unmarshal(ds);
 
 		FFirePDU firePDU;
 		firePDU.SetupFromOpenDIS(receivedFirePDU);
 
 		OnFirePDUProcessed.Broadcast(firePDU);
 
-		break;
+		return;
 	}
 	case EPDUType::Detonation:
 	{
-		DIS::DetonationPdu* receivedDetonationPDU = new DIS::DetonationPdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedDetonationPDU->unmarshal(ds);
+		DIS::DetonationPdu receivedDetonationPDU;
+		receivedDetonationPDU.unmarshal(ds);
 
 		FDetonationPDU detonationPDU;
 		detonationPDU.SetupFromOpenDIS(receivedDetonationPDU);
 
 		OnDetonationPDUProcessed.Broadcast(detonationPDU);
 
-		break;
+		return;
 	}
 	case EPDUType::RemoveEntity:
 	{
-		DIS::RemoveEntityPdu* receivedRemoveEntityPDU = new DIS::RemoveEntityPdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedRemoveEntityPDU->unmarshal(ds);
+		DIS::RemoveEntityPdu receivedRemoveEntityPDU;
+		receivedRemoveEntityPDU.unmarshal(ds);
 
 		FRemoveEntityPDU removeEntityPDU;
 		removeEntityPDU.SetupFromOpenDIS(receivedRemoveEntityPDU);
 
 		OnRemoveEntityPDUProcessed.Broadcast(removeEntityPDU);
 
-		break;
+		return;
 	}
 	case EPDUType::Start_Resume:
 	{
-		DIS::StartResumePdu* receivedStartResumePDU = new DIS::StartResumePdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedStartResumePDU->unmarshal(ds);
+		DIS::StartResumePdu receivedStartResumePDU;
+		receivedStartResumePDU.unmarshal(ds);
 
 		FStartResumePDU StartResumePDU;
 		StartResumePDU.SetupFromOpenDIS(receivedStartResumePDU);
 
 		OnStartResumePDUProcessed.Broadcast(StartResumePDU);
 
-		break;
+		return;
 	}
 	case EPDUType::Stop_Freeze:
 	{
-		DIS::StopFreezePdu* receivedStopFreezePDU = new DIS::StopFreezePdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedStopFreezePDU->unmarshal(ds);
+		DIS::StopFreezePdu receivedStopFreezePDU;
+		receivedStopFreezePDU.unmarshal(ds);
 
 		FStopFreezePDU StopFreezePDU;
 		StopFreezePDU.SetupFromOpenDIS(receivedStopFreezePDU);
 
 		OnStopFreezePDUProcessed.Broadcast(StopFreezePDU);
 
-		break;
+		return;
 	}
 	case EPDUType::EntityStateUpdate:
 	{
-		DIS::EntityStateUpdatePdu* receivedESUPDU = new DIS::EntityStateUpdatePdu();
-		DIS::DataStream ds((char*)&InData[0], bytesArrayLength, BigEndian);
-		receivedESUPDU->unmarshal(ds);
+		DIS::EntityStateUpdatePdu receivedESUPDU;
+		receivedESUPDU.unmarshal(ds);
 
 		FEntityStateUpdatePDU entityStateUpdatePDU;
 		entityStateUpdatePDU.SetupFromOpenDIS(receivedESUPDU);
 
 		OnEntityStateUpdatePDUProcessed.Broadcast(entityStateUpdatePDU);
 
-		break;
-	}
-	default:
-	{
-		break;
+		return;
 	}
 	}
 }

--- a/Source/DISRuntime/Public/DISEnumsAndStructs.h
+++ b/Source/DISRuntime/Public/DISEnumsAndStructs.h
@@ -669,7 +669,7 @@ struct FEntityType
 
 	double ToDouble() const
 	{
-		uint8_t* temp = new uint8[8];
+		uint8_t temp[8];
 		temp[0] = Extra;
 		temp[1] = Specific;
 		temp[2] = Subcategory;

--- a/Source/DISRuntime/Public/PDUProcessor.h
+++ b/Source/DISRuntime/Public/PDUProcessor.h
@@ -36,7 +36,7 @@ public:
 	 * @param InData - The DIS packet in bytes to process.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "GRILL DIS|PDU Processor")
-		void ProcessDISPacket(TArray<uint8> InData);
+		void ProcessDISPacket(const TArray<uint8>& InData);
 	
 	/**
 	 * Called after an Entity State PDU is processed.

--- a/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityInformationFamilyPDU.h
+++ b/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityInformationFamilyPDU.h
@@ -20,7 +20,7 @@ struct FEntityInformationFamilyPDU : public FPDU
 
 	virtual ~FEntityInformationFamilyPDU() {}
 
-	void SetupFromOpenDIS(DIS::EntityInformationFamilyPdu* EntityInfoFamilyPDUIn)
+	void SetupFromOpenDIS(const DIS::EntityInformationFamilyPdu& EntityInfoFamilyPDUIn)
 	{
 		FPDU::SetupFromOpenDIS(EntityInfoFamilyPDUIn);
 	}

--- a/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStatePDU.h
+++ b/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStatePDU.h
@@ -66,57 +66,57 @@ struct FEntityStatePDU : public FEntityInformationFamilyPDU
 
 	virtual ~FEntityStatePDU() {}
 
-	void SetupFromOpenDIS(DIS::EntityStatePdu* EntityStatePDUIn)
+	void SetupFromOpenDIS(const DIS::EntityStatePdu& EntityStatePDUIn)
 	{
 		FEntityInformationFamilyPDU::SetupFromOpenDIS(EntityStatePDUIn);
 
 		// Entity State PDU specifics
 		//entity id
-		EntityID = EntityStatePDUIn->getEntityID();
+		EntityID = EntityStatePDUIn.getEntityID();
 
 		//location
-		EcefLocation[0] = EntityStatePDUIn->getEntityLocation().getX();
-		EcefLocation[1] = EntityStatePDUIn->getEntityLocation().getY();
-		EcefLocation[2] = EntityStatePDUIn->getEntityLocation().getZ();
+		EcefLocation[0] = EntityStatePDUIn.getEntityLocation().getX();
+		EcefLocation[1] = EntityStatePDUIn.getEntityLocation().getY();
+		EcefLocation[2] = EntityStatePDUIn.getEntityLocation().getZ();
 
 		//rotation
-		DIS::Orientation& rotation = EntityStatePDUIn->getEntityOrientation();
+		const DIS::Orientation& rotation = EntityStatePDUIn.getEntityOrientation();
 		EntityOrientation.Yaw = rotation.getPsi();
 		EntityOrientation.Roll = rotation.getPhi();
 		EntityOrientation.Pitch = rotation.getTheta();
 
 		//velocity (originally in float so this is fine)
-		EntityLinearVelocity[0] = EntityStatePDUIn->getEntityLinearVelocity().getX();
-		EntityLinearVelocity[1] = EntityStatePDUIn->getEntityLinearVelocity().getY();
-		EntityLinearVelocity[2] = EntityStatePDUIn->getEntityLinearVelocity().getZ();
+		EntityLinearVelocity[0] = EntityStatePDUIn.getEntityLinearVelocity().getX();
+		EntityLinearVelocity[1] = EntityStatePDUIn.getEntityLinearVelocity().getY();
+		EntityLinearVelocity[2] = EntityStatePDUIn.getEntityLinearVelocity().getZ();
 
 		//Dead reckoning
-		DeadReckoningParameters.DeadReckoningAlgorithm = static_cast<EDeadReckoningAlgorithm>(EntityStatePDUIn->getDeadReckoningParameters().getDeadReckoningAlgorithm());
-		DeadReckoningParameters.OtherParameters = TArray<uint8>(reinterpret_cast<uint8*>(EntityStatePDUIn->getDeadReckoningParameters().getOtherParameters()), 15);
-		DeadReckoningParameters.EntityLinearAcceleration[0] = EntityStatePDUIn->getDeadReckoningParameters().getEntityLinearAcceleration().getX();
-		DeadReckoningParameters.EntityLinearAcceleration[1] = EntityStatePDUIn->getDeadReckoningParameters().getEntityLinearAcceleration().getY();
-		DeadReckoningParameters.EntityLinearAcceleration[2] = EntityStatePDUIn->getDeadReckoningParameters().getEntityLinearAcceleration().getZ();
-		DeadReckoningParameters.EntityAngularVelocity[0] = EntityStatePDUIn->getDeadReckoningParameters().getEntityAngularVelocity().getX();
-		DeadReckoningParameters.EntityAngularVelocity[1] = EntityStatePDUIn->getDeadReckoningParameters().getEntityAngularVelocity().getY();
-		DeadReckoningParameters.EntityAngularVelocity[2] = EntityStatePDUIn->getDeadReckoningParameters().getEntityAngularVelocity().getZ();
+		DeadReckoningParameters.DeadReckoningAlgorithm = static_cast<EDeadReckoningAlgorithm>(EntityStatePDUIn.getDeadReckoningParameters().getDeadReckoningAlgorithm());
+		DeadReckoningParameters.OtherParameters = TArray<uint8>(reinterpret_cast<const uint8*>(EntityStatePDUIn.getDeadReckoningParameters().getOtherParameters()), 15);
+		DeadReckoningParameters.EntityLinearAcceleration[0] = EntityStatePDUIn.getDeadReckoningParameters().getEntityLinearAcceleration().getX();
+		DeadReckoningParameters.EntityLinearAcceleration[1] = EntityStatePDUIn.getDeadReckoningParameters().getEntityLinearAcceleration().getY();
+		DeadReckoningParameters.EntityLinearAcceleration[2] = EntityStatePDUIn.getDeadReckoningParameters().getEntityLinearAcceleration().getZ();
+		DeadReckoningParameters.EntityAngularVelocity[0] = EntityStatePDUIn.getDeadReckoningParameters().getEntityAngularVelocity().getX();
+		DeadReckoningParameters.EntityAngularVelocity[1] = EntityStatePDUIn.getDeadReckoningParameters().getEntityAngularVelocity().getY();
+		DeadReckoningParameters.EntityAngularVelocity[2] = EntityStatePDUIn.getDeadReckoningParameters().getEntityAngularVelocity().getZ();
 
 		//single vars
-		ForceID = static_cast<EForceID>(EntityStatePDUIn->getForceId());
-		Marking = FString(EntityStatePDUIn->getMarking().getCharacters());
+		ForceID = static_cast<EForceID>(EntityStatePDUIn.getForceId());
+		Marking = FString(EntityStatePDUIn.getMarking().getCharacters());
 		Marking.LeftInline(11);
-		EntityAppearance = FEntityAppearance(EntityStatePDUIn->getEntityAppearance());
-		Capabilities = EntityStatePDUIn->getCapabilities();
+		EntityAppearance = EntityStatePDUIn.getEntityAppearance();
+		Capabilities = EntityStatePDUIn.getCapabilities();
 
 		//Entity type
-		EntityType = EntityStatePDUIn->getEntityType();
+		EntityType = EntityStatePDUIn.getEntityType();
 
 		//Alternative Entity type
-		AlternativeEntityType = EntityStatePDUIn->getAlternativeEntityType();
+		AlternativeEntityType = EntityStatePDUIn.getAlternativeEntityType();
 
 		//Articulation Parameters
-		for (int i = 0; i < EntityStatePDUIn->getNumberOfArticulationParameters(); i++)
+		for (int i = 0; i < EntityStatePDUIn.getNumberOfArticulationParameters(); i++)
 		{
-			DIS::ArticulationParameter tempArtParam = EntityStatePDUIn->getArticulationParameters()[i];
+			DIS::ArticulationParameter tempArtParam = EntityStatePDUIn.getArticulationParameters()[i];
 			FArticulationParameters newArtParam;
 			newArtParam.ParameterTypeDesignator = tempArtParam.getParameterTypeDesignator();
 			newArtParam.ChangeIndicator = tempArtParam.getChangeIndicator();
@@ -218,7 +218,7 @@ struct FEntityStatePDU : public FEntityInformationFamilyPDU
 		return newESUPDU;
 	}
 
-	FEntityStatePDU& operator = (FEntityStateUpdatePDU EntityStateUpdatePDUIn)
+	FEntityStatePDU& operator = (const FEntityStateUpdatePDU& EntityStateUpdatePDUIn)
 	{
 		//pdu common parameters
 		ProtocolVersion = EntityStateUpdatePDUIn.ProtocolVersion;

--- a/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStateUpdatePDU.h
+++ b/Source/DISRuntime/Public/PDUs/EntityInfoFamily/GRILL_EntityStateUpdatePDU.h
@@ -49,38 +49,38 @@ struct FEntityStateUpdatePDU : public FEntityInformationFamilyPDU
 
 	virtual ~FEntityStateUpdatePDU() {}
 
-	void SetupFromOpenDIS(DIS::EntityStateUpdatePdu* EntityStateUpdatePDUIn)
+	void SetupFromOpenDIS(const DIS::EntityStateUpdatePdu& EntityStateUpdatePDUIn)
 	{
 		FEntityInformationFamilyPDU::SetupFromOpenDIS(EntityStateUpdatePDUIn);
 
 		//Entity State Update specifics
 		//entity id
-		EntityID = EntityStateUpdatePDUIn->getEntityID();
+		EntityID = EntityStateUpdatePDUIn.getEntityID();
 
 		//location
-		EcefLocation[0] = EntityStateUpdatePDUIn->getEntityLocation().getX();
-		EcefLocation[1] = EntityStateUpdatePDUIn->getEntityLocation().getY();
-		EcefLocation[2] = EntityStateUpdatePDUIn->getEntityLocation().getZ();
+		EcefLocation[0] = EntityStateUpdatePDUIn.getEntityLocation().getX();
+		EcefLocation[1] = EntityStateUpdatePDUIn.getEntityLocation().getY();
+		EcefLocation[2] = EntityStateUpdatePDUIn.getEntityLocation().getZ();
 
 		//rotation
-		DIS::Orientation& rotation = EntityStateUpdatePDUIn->getEntityOrientation();
+		const DIS::Orientation& rotation = EntityStateUpdatePDUIn.getEntityOrientation();
 		EntityOrientation.Yaw = rotation.getPsi();
 		EntityOrientation.Roll = rotation.getPhi();
 		EntityOrientation.Pitch = rotation.getTheta();
 
 		//velocity (originally in float so this is fine)
-		EntityLinearVelocity[0] = EntityStateUpdatePDUIn->getEntityLinearVelocity().getX();
-		EntityLinearVelocity[1] = EntityStateUpdatePDUIn->getEntityLinearVelocity().getY();
-		EntityLinearVelocity[2] = EntityStateUpdatePDUIn->getEntityLinearVelocity().getZ();
+		EntityLinearVelocity[0] = EntityStateUpdatePDUIn.getEntityLinearVelocity().getX();
+		EntityLinearVelocity[1] = EntityStateUpdatePDUIn.getEntityLinearVelocity().getY();
+		EntityLinearVelocity[2] = EntityStateUpdatePDUIn.getEntityLinearVelocity().getZ();
 
 		//Single Vars
-		Padding1 = EntityStateUpdatePDUIn->getPadding1();
-		EntityAppearance = FEntityAppearance(EntityStateUpdatePDUIn->getEntityAppearance());
+		Padding1 = EntityStateUpdatePDUIn.getPadding1();
+		EntityAppearance = EntityStateUpdatePDUIn.getEntityAppearance();
 
 		//Articulation Parameters
-		for (int i = 0; i < EntityStateUpdatePDUIn->getNumberOfArticulationParameters(); i++)
+		for (int i = 0; i < EntityStateUpdatePDUIn.getNumberOfArticulationParameters(); i++)
 		{
-			DIS::ArticulationParameter tempArtParam = EntityStateUpdatePDUIn->getArticulationParameters()[i];
+			DIS::ArticulationParameter tempArtParam = EntityStateUpdatePDUIn.getArticulationParameters()[i];
 			FArticulationParameters newArtParam;
 			newArtParam.ParameterTypeDesignator = tempArtParam.getParameterTypeDesignator();
 			newArtParam.ChangeIndicator = tempArtParam.getChangeIndicator();

--- a/Source/DISRuntime/Public/PDUs/GRILL_PDU.h
+++ b/Source/DISRuntime/Public/PDUs/GRILL_PDU.h
@@ -51,15 +51,15 @@ struct FPDU
 
 	virtual ~FPDU() {}
 
-	void SetupFromOpenDIS(DIS::Pdu* PDUIn)
+	void SetupFromOpenDIS(const DIS::Pdu& PDUIn)
 	{
-		ProtocolVersion = PDUIn->getProtocolVersion();
-		ExerciseID = PDUIn->getExerciseID();
-		PduType = static_cast<EPDUType>(PDUIn->getPduType());
-		ProtocolFamily = PDUIn->getProtocolFamily();
-		Timestamp = PDUIn->getTimestamp();
-		Length = PDUIn->getLength();
-		Padding = PDUIn->getPadding();
+		ProtocolVersion = PDUIn.getProtocolVersion();
+		ExerciseID = PDUIn.getExerciseID();
+		PduType = static_cast<EPDUType>(PDUIn.getPduType());
+		ProtocolFamily = PDUIn.getProtocolFamily();
+		Timestamp = PDUIn.getTimestamp();
+		Length = PDUIn.getLength();
+		Padding = PDUIn.getPadding();
 	}
 
 	void ToOpenDIS(DIS::Pdu& PDUOut)
@@ -85,7 +85,7 @@ struct FPDU
 		return DISDataStreamToBytes(buffer);
 	}
 
-	TArray<uint8> DISDataStreamToBytes(DIS::DataStream DataStream) 
+	TArray<uint8> DISDataStreamToBytes(const DIS::DataStream& DataStream) 
 	{
 		TArray<uint8> byteArrayOut;
 		byteArrayOut.Init(0, DataStream.size());

--- a/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_RemoveEntityPDU.h
+++ b/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_RemoveEntityPDU.h
@@ -26,11 +26,11 @@ struct FRemoveEntityPDU : public FSimulationManagementFamilyPDU
 
 	virtual ~FRemoveEntityPDU() {}
 
-	void SetupFromOpenDIS(DIS::RemoveEntityPdu* RemoveEntityPDUIn)
+	void SetupFromOpenDIS(const DIS::RemoveEntityPdu& RemoveEntityPDUIn)
 	{
 		FSimulationManagementFamilyPDU::SetupFromOpenDIS(RemoveEntityPDUIn);
 
-		RequestID = RemoveEntityPDUIn->getRequestID();
+		RequestID = RemoveEntityPDUIn.getRequestID();
 	}
 
 	void ToOpenDIS(DIS::RemoveEntityPdu& RemoveEntityPDUOut)

--- a/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_SimulationManagementFamilyPDU.h
+++ b/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_SimulationManagementFamilyPDU.h
@@ -27,12 +27,12 @@ struct FSimulationManagementFamilyPDU : public FPDU
 
     virtual ~FSimulationManagementFamilyPDU() {}
 
-    void SetupFromOpenDIS(DIS::SimulationManagementFamilyPdu* SimFamilyPDUIn)
+    void SetupFromOpenDIS(const DIS::SimulationManagementFamilyPdu& SimFamilyPDUIn)
     {
         FPDU::SetupFromOpenDIS(SimFamilyPDUIn);
 
-        OriginatingEntityID = SimFamilyPDUIn->getOriginatingEntityID();
-        ReceivingEntityID = SimFamilyPDUIn->getReceivingEntityID();
+        OriginatingEntityID = SimFamilyPDUIn.getOriginatingEntityID();
+        ReceivingEntityID = SimFamilyPDUIn.getReceivingEntityID();
     }
 
     void ToOpenDIS(DIS::SimulationManagementFamilyPdu& simFamilyPDUOut)

--- a/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_StartResumePDU.h
+++ b/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_StartResumePDU.h
@@ -32,13 +32,13 @@ struct FStartResumePDU : public FSimulationManagementFamilyPDU
 
 	virtual ~FStartResumePDU() {}
 
-	void SetupFromOpenDIS(DIS::StartResumePdu* StartResumePDUIn)
+	void SetupFromOpenDIS(const DIS::StartResumePdu& StartResumePDUIn)
 	{
 		FSimulationManagementFamilyPDU::SetupFromOpenDIS(StartResumePDUIn);
 
 		// Start/Resume PDU specific
-		DIS::ClockTime tempRealWorldTime = StartResumePDUIn->getRealWorldTime();
-		DIS::ClockTime tempSimulationTime = StartResumePDUIn->getRealWorldTime();
+		DIS::ClockTime tempRealWorldTime = StartResumePDUIn.getRealWorldTime();
+		DIS::ClockTime tempSimulationTime = StartResumePDUIn.getRealWorldTime();
 
 		RealWorldTime.Hour = tempRealWorldTime.getHour();
 		RealWorldTime.TimePastHour = tempRealWorldTime.getTimePastHour();
@@ -46,7 +46,7 @@ struct FStartResumePDU : public FSimulationManagementFamilyPDU
 		SimulationTime.Hour = tempSimulationTime.getHour();
 		SimulationTime.TimePastHour = tempSimulationTime.getTimePastHour();
 
-		RequestID = StartResumePDUIn->getRequestID();
+		RequestID = StartResumePDUIn.getRequestID();
 	}
 
 	void ToOpenDIS(DIS::StartResumePdu& StartResumePDUOut)

--- a/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_StopFreezePDU.h
+++ b/Source/DISRuntime/Public/PDUs/SimManagementFamily/GRILL_StopFreezePDU.h
@@ -41,20 +41,20 @@ struct FStopFreezePDU : public FSimulationManagementFamilyPDU
 
 	virtual ~FStopFreezePDU() {}
 
-	void SetupFromOpenDIS(DIS::StopFreezePdu* StopFreezePDUIn)
+	void SetupFromOpenDIS(const DIS::StopFreezePdu& StopFreezePDUIn)
 	{
 		FSimulationManagementFamilyPDU::SetupFromOpenDIS(StopFreezePDUIn);
 
 		// Stop/Freeze PDU specifics
-		DIS::ClockTime tempRealWorldTime = StopFreezePDUIn->getRealWorldTime();
+		DIS::ClockTime tempRealWorldTime = StopFreezePDUIn.getRealWorldTime();
 
 		RealWorldTime.Hour = tempRealWorldTime.getHour();
 		RealWorldTime.TimePastHour = tempRealWorldTime.getTimePastHour();
 
-		Reason = static_cast<EReason>(StopFreezePDUIn->getReason());
-		FrozenBehavior = StopFreezePDUIn->getFrozenBehavior();
-		PaddingOne = StopFreezePDUIn->getPadding1();
-		RequestID = StopFreezePDUIn->getRequestID();
+		Reason = static_cast<EReason>(StopFreezePDUIn.getReason());
+		FrozenBehavior = StopFreezePDUIn.getFrozenBehavior();
+		PaddingOne = StopFreezePDUIn.getPadding1();
+		RequestID = StopFreezePDUIn.getRequestID();
 	}
 
 	void ToOpenDIS(DIS::StopFreezePdu& StopFreezePDUOut)

--- a/Source/DISRuntime/Public/PDUs/WarfareFamily/GRILL_DetonationPDU.h
+++ b/Source/DISRuntime/Public/PDUs/WarfareFamily/GRILL_DetonationPDU.h
@@ -58,47 +58,47 @@ struct FDetonationPDU : public FWarfareFamilyPDU
 
 	virtual ~FDetonationPDU() {}
 
-	void SetupFromOpenDIS(DIS::DetonationPdu* DetonationPDUIn)
+	void SetupFromOpenDIS(const DIS::DetonationPdu& DetonationPDUIn)
 	{
 		FWarfareFamilyPDU::SetupFromOpenDIS(DetonationPDUIn);
 
 		//Detonation PDU specifics
 		//MunitionEntityID
-		MunitionEntityID = DetonationPDUIn->getMunitionID();
+		MunitionEntityID = DetonationPDUIn.getMunitionID();
 
 		//event id
-		EventID = DetonationPDUIn->getEventID();
+		EventID = DetonationPDUIn.getEventID();
 
 		//velocity
-		Velocity[0] = DetonationPDUIn->getVelocity().getX();
-		Velocity[1] = DetonationPDUIn->getVelocity().getY();
-		Velocity[2] = DetonationPDUIn->getVelocity().getZ();
+		Velocity[0] = DetonationPDUIn.getVelocity().getX();
+		Velocity[1] = DetonationPDUIn.getVelocity().getY();
+		Velocity[2] = DetonationPDUIn.getVelocity().getZ();
 
 		//location
-		EcefLocation[0] = DetonationPDUIn->getLocationInWorldCoordinates().getX();
-		EcefLocation[1] = DetonationPDUIn->getLocationInWorldCoordinates().getY();
-		EcefLocation[2] = DetonationPDUIn->getLocationInWorldCoordinates().getZ();
+		EcefLocation[0] = DetonationPDUIn.getLocationInWorldCoordinates().getX();
+		EcefLocation[1] = DetonationPDUIn.getLocationInWorldCoordinates().getY();
+		EcefLocation[2] = DetonationPDUIn.getLocationInWorldCoordinates().getZ();
 
 		//location
-		LocationInEntityCoords[0] = DetonationPDUIn->getLocationInEntityCoordinates().getX();
-		LocationInEntityCoords[1] = DetonationPDUIn->getLocationInEntityCoordinates().getY();
-		LocationInEntityCoords[2] = DetonationPDUIn->getLocationInEntityCoordinates().getZ();
+		LocationInEntityCoords[0] = DetonationPDUIn.getLocationInEntityCoordinates().getX();
+		LocationInEntityCoords[1] = DetonationPDUIn.getLocationInEntityCoordinates().getY();
+		LocationInEntityCoords[2] = DetonationPDUIn.getLocationInEntityCoordinates().getZ();
 
 		//burst descriptor
-		BurstDescriptor.Warhead = DetonationPDUIn->getBurstDescriptor().getWarhead();
-		BurstDescriptor.Fuse = DetonationPDUIn->getBurstDescriptor().getFuse();
-		BurstDescriptor.Rate = DetonationPDUIn->getBurstDescriptor().getRate();
-		BurstDescriptor.Quantity = DetonationPDUIn->getBurstDescriptor().getQuantity();
-		BurstDescriptor.EntityType = DetonationPDUIn->getBurstDescriptor().getMunition();
+		BurstDescriptor.Warhead = DetonationPDUIn.getBurstDescriptor().getWarhead();
+		BurstDescriptor.Fuse = DetonationPDUIn.getBurstDescriptor().getFuse();
+		BurstDescriptor.Rate = DetonationPDUIn.getBurstDescriptor().getRate();
+		BurstDescriptor.Quantity = DetonationPDUIn.getBurstDescriptor().getQuantity();
+		BurstDescriptor.EntityType = DetonationPDUIn.getBurstDescriptor().getMunition();
 
 		//single vars
-		DetonationResult = static_cast<EDetonationResult>(DetonationPDUIn->getDetonationResult());
-		Pad = DetonationPDUIn->getPad();
+		DetonationResult = static_cast<EDetonationResult>(DetonationPDUIn.getDetonationResult());
+		Pad = DetonationPDUIn.getPad();
 
 		//Articulation Parameters
-		for (int i = 0; i < DetonationPDUIn->getNumberOfArticulationParameters(); i++)
+		for (int i = 0; i < DetonationPDUIn.getNumberOfArticulationParameters(); i++)
 		{
-			DIS::ArticulationParameter tempArtParam = DetonationPDUIn->getArticulationParameters()[i];
+			DIS::ArticulationParameter tempArtParam = DetonationPDUIn.getArticulationParameters()[i];
 			FArticulationParameters newArtParam;
 			newArtParam.ParameterTypeDesignator = tempArtParam.getParameterTypeDesignator();
 			newArtParam.ChangeIndicator = tempArtParam.getChangeIndicator();

--- a/Source/DISRuntime/Public/PDUs/WarfareFamily/GRILL_FirePDU.h
+++ b/Source/DISRuntime/Public/PDUs/WarfareFamily/GRILL_FirePDU.h
@@ -61,39 +61,39 @@ struct FFirePDU : public FWarfareFamilyPDU
 
 	virtual ~FFirePDU() {}
 
-	void SetupFromOpenDIS(DIS::FirePdu* FirePDUIn)
+	void SetupFromOpenDIS(const DIS::FirePdu& FirePDUIn)
 	{
 		FWarfareFamilyPDU::SetupFromOpenDIS(FirePDUIn);
 
 		// Fire PDU specifics
 		//single vars
-		FireMissionIndex = FirePDUIn->getFireMissionIndex();
-		Range = FirePDUIn->getRange();
+		FireMissionIndex = FirePDUIn.getFireMissionIndex();
+		Range = FirePDUIn.getRange();
 
 		//MunitionEntityID
-		MunitionEntityID.Site = FirePDUIn->getMunitionID().getSite();
-		MunitionEntityID.Application = FirePDUIn->getMunitionID().getApplication();
-		MunitionEntityID.Entity = FirePDUIn->getMunitionID().getEntity();
+		MunitionEntityID.Site = FirePDUIn.getMunitionID().getSite();
+		MunitionEntityID.Application = FirePDUIn.getMunitionID().getApplication();
+		MunitionEntityID.Entity = FirePDUIn.getMunitionID().getEntity();
 
 		//velocity
-		Velocity[0] = FirePDUIn->getVelocity().getX();
-		Velocity[1] = FirePDUIn->getVelocity().getY();
-		Velocity[2] = FirePDUIn->getVelocity().getZ();
+		Velocity[0] = FirePDUIn.getVelocity().getX();
+		Velocity[1] = FirePDUIn.getVelocity().getY();
+		Velocity[2] = FirePDUIn.getVelocity().getZ();
 
 		//location
-		EcefLocation[0] = FirePDUIn->getLocationInWorldCoordinates().getX();
-		EcefLocation[1] = FirePDUIn->getLocationInWorldCoordinates().getY();
-		EcefLocation[2] = FirePDUIn->getLocationInWorldCoordinates().getZ();
+		EcefLocation[0] = FirePDUIn.getLocationInWorldCoordinates().getX();
+		EcefLocation[1] = FirePDUIn.getLocationInWorldCoordinates().getY();
+		EcefLocation[2] = FirePDUIn.getLocationInWorldCoordinates().getZ();
 
 		//event id
-		EventID = FirePDUIn->getEventID();
+		EventID = FirePDUIn.getEventID();
 
 		//burst descriptor
-		BurstDescriptor.Warhead = FirePDUIn->getBurstDescriptor().getWarhead();
-		BurstDescriptor.Fuse = FirePDUIn->getBurstDescriptor().getFuse();
-		BurstDescriptor.Rate = FirePDUIn->getBurstDescriptor().getRate();
-		BurstDescriptor.Quantity = FirePDUIn->getBurstDescriptor().getQuantity();
-		BurstDescriptor.EntityType = FirePDUIn->getBurstDescriptor().getMunition();
+		BurstDescriptor.Warhead = FirePDUIn.getBurstDescriptor().getWarhead();
+		BurstDescriptor.Fuse = FirePDUIn.getBurstDescriptor().getFuse();
+		BurstDescriptor.Rate = FirePDUIn.getBurstDescriptor().getRate();
+		BurstDescriptor.Quantity = FirePDUIn.getBurstDescriptor().getQuantity();
+		BurstDescriptor.EntityType = FirePDUIn.getBurstDescriptor().getMunition();
 	}
 
 	void ToOpenDIS(DIS::FirePdu& FirePDUOut)

--- a/Source/DISRuntime/Public/PDUs/WarfareFamily/GRILL_WarfareFamilyPDU.h
+++ b/Source/DISRuntime/Public/PDUs/WarfareFamily/GRILL_WarfareFamilyPDU.h
@@ -27,12 +27,12 @@ struct FWarfareFamilyPDU : public FPDU
 
 	virtual ~FWarfareFamilyPDU() {}
 
-	void SetupFromOpenDIS(DIS::WarfareFamilyPdu* WarfareFamilyPDUIn)
+	void SetupFromOpenDIS(const DIS::WarfareFamilyPdu& WarfareFamilyPDUIn)
 	{
 		FPDU::SetupFromOpenDIS(WarfareFamilyPDUIn);
 
-		FiringEntityID = WarfareFamilyPDUIn->getFiringEntityID();
-		TargetEntityID = WarfareFamilyPDUIn->getTargetEntityID();
+		FiringEntityID = WarfareFamilyPDUIn.getFiringEntityID();
+		TargetEntityID = WarfareFamilyPDUIn.getTargetEntityID();
 	}
 
 	void ToOpenDIS(DIS::WarfareFamilyPdu& WarfareFamilyPDUOut)


### PR DESCRIPTION
Each time a message was received, a new PDU was instantiated and never deleted.
To prevent this, PDU can be just constructed on the stack and passed around as const ref.