### PR TITLE
Add UE5.7 support and macOS/runtime compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ Plugins/*/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+Source/.DS_Store
+/Source/DISRuntime/Private/OpenDISGenerated
+/Source/ThirdParty/Binaries

--- a/Source/DISRuntime/DISRuntime.Build.cs
+++ b/Source/DISRuntime/DISRuntime.Build.cs
@@ -1,5 +1,3 @@
-// Copyright 2022 Gaming Research Integration for Learning Lab. All Rights Reserved.
-
 using UnrealBuildTool;
 using System.IO;
 
@@ -15,6 +13,7 @@ public class DISRuntime : ModuleRules
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		bEnableExceptions = true;
+		bUseUnity = false;
 
 		PublicDependencyModuleNames.AddRange(
 			new string[]
@@ -36,14 +35,16 @@ public class DISRuntime : ModuleRules
 				"SlateCore"
 			}
 			);
-		
-        string BinaryPath = Path.Combine(ThirdPartyPath, "Binaries");
-		string WinPath = Path.Combine(BinaryPath, "Win64");
-        PublicSystemLibraryPaths.Add(WinPath);
-        PublicAdditionalLibraries.Add(Path.Combine(WinPath, "OpenDIS6.lib"));
-        PublicIncludePaths.Add(Path.Combine(ThirdPartyPath, "include"));
-		
-		PublicDelayLoadDLLs.Add("OpenDIS6.dll");
-		RuntimeDependencies.Add(Path.Combine(WinPath, "OpenDIS6.dll"));
+
+		PublicIncludePaths.Add(Path.Combine(ThirdPartyPath, "include"));
+		PublicDefinitions.Add("OPENDIS6_STATIC_DEFINE=1");
+		PublicDefinitions.Add("OPENDIS7_STATIC_DEFINE=1");
+		PublicDefinitions.Add("GRILL_DIS_SUPPORTS_WIN64=1");
+		PublicDefinitions.Add("GRILL_DIS_SUPPORTS_MAC=1");
+
+		if (Target.Platform != UnrealTargetPlatform.Win64 && Target.Platform != UnrealTargetPlatform.Mac)
+		{
+			throw new BuildException("GRILL DIS for Unreal currently supports Win64 and Mac.");
+		}
 	}
 }

--- a/Source/DISRuntime/Private/DISGameManager.cpp
+++ b/Source/DISRuntime/Private/DISGameManager.cpp
@@ -3,8 +3,11 @@
 #include "DISGameManager.h"
 #include "Kismet/GameplayStatics.h"
 #include "DIS_BPFL.h"
+#include "DISSendComponent.h"
+#include "DISReceiveComponent.h"
 #include "Engine/Engine.h"
 #include "Engine/GameInstance.h"
+#include "EngineUtils.h"
 #include "PDUProcessor.h"
 
 DEFINE_LOG_CATEGORY(LogDISGameManager);
@@ -115,6 +118,8 @@ void ADISGameManager::BeginPlay()
 	{
 		UE_LOG(LogDISGameManager, Error, TEXT("No DIS Class Enum Mapping has been set within the DIS Game Manager actor!"));
 	}
+
+	RefreshLocalSendOnlyEntityIDs();
 }
 
 void ADISGameManager::Tick(float DeltaTime)
@@ -155,6 +160,8 @@ void ADISGameManager::HandleOnDISEntityDestroyed(AActor* DestroyedActor)
 		anyRemoved = RemoveDISEntityFromMap(DISComponent->EntityID);
 	}
 
+	RefreshLocalSendOnlyEntityIDs();
+
 	if (!anyRemoved)
 	{
 		UE_LOG(LogDISGameManager, Error, TEXT("Failed to remove %s from the Entity Map!"), *DestroyedActor->GetName());
@@ -165,6 +172,11 @@ void ADISGameManager::HandleEntityStatePDU(FEntityStatePDU EntityStatePDUIn)
 {
 	if (EntityStatePDUIn.ExerciseID == ExerciseID)
 	{
+		if (ShouldIgnoreLocallySentEntityStatePDU(EntityStatePDUIn))
+		{
+			return;
+		}
+
 		//Find associated actor in the DISActorMappings map -- If actor does not exist spawn one
 		auto associatedActor = DISActorMappings.Find(EntityStatePDUIn.EntityID);
 		if (associatedActor != nullptr && *associatedActor != nullptr)
@@ -188,6 +200,58 @@ void ADISGameManager::HandleEntityStatePDU(FEntityStatePDU EntityStatePDUIn)
 
 			SpawnNewEntityFromEntityState(EntityStatePDUIn);
 		}
+	}
+}
+
+bool ADISGameManager::ShouldIgnoreLocallySentEntityStatePDU(const FEntityStatePDU& EntityStatePDUIn) const
+{
+	if (EntityStatePDUIn.EntityID.Site != SiteID || EntityStatePDUIn.EntityID.Application != ApplicationID)
+	{
+		return false;
+	}
+
+	if (LocalSendOnlyEntityIDs.Contains(EntityStatePDUIn.EntityID.Entity))
+	{
+		return true;
+	}
+
+	ADISGameManager* MutableThis = const_cast<ADISGameManager*>(this);
+	MutableThis->RefreshLocalSendOnlyEntityIDs();
+
+	return LocalSendOnlyEntityIDs.Contains(EntityStatePDUIn.EntityID.Entity);
+}
+
+void ADISGameManager::RefreshLocalSendOnlyEntityIDs()
+{
+	LocalSendOnlyEntityIDs.Reset();
+
+	UWorld* World = GetWorld();
+	if (World == nullptr)
+	{
+		return;
+	}
+
+	for (TActorIterator<AActor> ActorIt(World); ActorIt; ++ActorIt)
+	{
+		AActor* Actor = *ActorIt;
+		if (!IsValid(Actor))
+		{
+			continue;
+		}
+
+		UDISSendComponent* SendComponent = Actor->FindComponentByClass<UDISSendComponent>();
+		if (SendComponent == nullptr)
+		{
+			continue;
+		}
+
+		UDISReceiveComponent* ReceiveComponent = Actor->FindComponentByClass<UDISReceiveComponent>();
+		if (ReceiveComponent != nullptr)
+		{
+			continue;
+		}
+
+		LocalSendOnlyEntityIDs.Add(SendComponent->EntityID);
 	}
 }
 

--- a/Source/DISRuntime/Private/DISReceiveComponent.cpp
+++ b/Source/DISRuntime/Private/DISReceiveComponent.cpp
@@ -274,9 +274,11 @@ bool UDISReceiveComponent::GroundClamping_Implementation()
 				GetOwner()->SetActorLocationAndRotation(clampLocation, clampRotation);
 			}
 			OnGroundClampingUpdate.Broadcast(allClampTransforms);
+			return true;
 		}
 
-		return true;
+		// No valid ground hit was found, so allow callers to fall back to the raw DIS transform.
+		return false;
 	}
 	else
 	{

--- a/Source/DISRuntime/Private/DISRuntime.cpp
+++ b/Source/DISRuntime/Private/DISRuntime.cpp
@@ -1,32 +1,14 @@
-// Copyright 2022 Gaming Research Integration for Learning Lab. All Rights Reserved.
-
 #include "DISRuntime.h"
-#include "Interfaces/IPluginManager.h"
-#include "Windows/WindowsPlatformProcess.h"
 
 #define LOCTEXT_NAMESPACE "FDISRuntime"
 
 void FDISRuntimeModule::StartupModule()
 {
-	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
-	//Get the location of the GRILL DIS Plugin folder
-	TSharedPtr<IPlugin> GrillDIS = IPluginManager::Get().FindPlugin("GRILLDISForUnreal");
-
-	if (GrillDIS)
-	{
-		//Append the location of the OpenDIS6.dll within the plugin folder
-		FString openDISPluginDir = GrillDIS->GetBaseDir().Append("\\Source\\ThirdParty\\Binaries\\Win64\\OpenDIS6.dll");
-		DLLHandle = FPlatformProcess::GetDllHandle(*openDISPluginDir);
-	}
+	// OpenDIS is compiled into the module for all supported platforms.
 }
 
 void FDISRuntimeModule::ShutdownModule()
 {
-	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-	// we call this function before unloading the module.
-
-	//Free the loaded OpenDIS6 DLL
-	FPlatformProcess::FreeDllHandle(DLLHandle);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/DISRuntime/Private/DIS_BPFL.cpp
+++ b/Source/DISRuntime/Private/DIS_BPFL.cpp
@@ -6,6 +6,35 @@
 
 DEFINE_LOG_CATEGORY(LogDIS_BPFL);
 
+FString UDIS_BPFL::GetCurrentPlatformName()
+{
+#if PLATFORM_WINDOWS
+	return TEXT("Windows");
+#elif PLATFORM_MAC
+	return TEXT("Mac");
+#else
+	return FPlatformProperties::PlatformName();
+#endif
+}
+
+bool UDIS_BPFL::IsRunningOnWindows()
+{
+#if PLATFORM_WINDOWS
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UDIS_BPFL::IsRunningOnMac()
+{
+#if PLATFORM_MAC
+	return true;
+#else
+	return false;
+#endif
+}
+
 bool UDIS_BPFL::CalculateLatLonAltitudeFromEcefXYZ(const FVector Ecef, FGeographicCoordinates& OutLatLonAltDegreesMeters)
 {
 	constexpr double earthEquitorialRadiusMeters = 6378137;

--- a/Source/DISRuntime/Public/DISGameManager.h
+++ b/Source/DISRuntime/Public/DISGameManager.h
@@ -235,7 +235,10 @@ protected:
 
 
 private:
+	bool ShouldIgnoreLocallySentEntityStatePDU(const FEntityStatePDU& EntityStatePDUIn) const;
+	void RefreshLocalSendOnlyEntityIDs();
 	void SpawnNewEntityFromEntityState(FEntityStatePDU EntityStatePDUIn);
 	UDISReceiveComponent* GetAssociatedDISComponent(FEntityID EntityIDIn);
 	AGeoReferencingSystem* GeoReferencingSystem;
+	TSet<int32> LocalSendOnlyEntityIDs;
 };

--- a/Source/DISRuntime/Public/DISRuntime.h
+++ b/Source/DISRuntime/Public/DISRuntime.h
@@ -8,11 +8,7 @@
 class FDISRuntimeModule : public IModuleInterface
 {
 public:
-
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
-
-protected:
-	void *DLLHandle;
 };

--- a/Source/DISRuntime/Public/DIS_BPFL.h
+++ b/Source/DISRuntime/Public/DIS_BPFL.h
@@ -61,6 +61,24 @@ private:
 
 public:
 	/**
+	 * Returns the current runtime platform that the DIS plugin is executing on.
+	 */
+	UFUNCTION(BlueprintPure, Category = "GRILL DIS|Platform")
+		static FString GetCurrentPlatformName();
+
+	/**
+	 * Returns whether the current runtime platform is Windows.
+	 */
+	UFUNCTION(BlueprintPure, Category = "GRILL DIS|Platform")
+		static bool IsRunningOnWindows();
+
+	/**
+	 * Returns whether the current runtime platform is macOS.
+	 */
+	UFUNCTION(BlueprintPure, Category = "GRILL DIS|Platform")
+		static bool IsRunningOnMac();
+
+	/**
 	 * Creates a 4x4 n^x matrix used for creating a rotation matrix
 	 * @param NVector A 3x1 vector representing the axis of rotation
 	 */

--- a/Source/ThirdParty/include/dis6/MinefieldQueryPdu.cpp
+++ b/Source/ThirdParty/include/dis6/MinefieldQueryPdu.cpp
@@ -107,17 +107,17 @@ void MinefieldQueryPdu::setRequestedMineType(const EntityType &pX)
     _requestedMineType = pX;
 }
 
-std::vector<Point>& MinefieldQueryPdu::getRequestedPerimeterPoints() 
+std::vector<DIS::Point>& MinefieldQueryPdu::getRequestedPerimeterPoints() 
 {
     return _requestedPerimeterPoints;
 }
 
-const std::vector<Point>& MinefieldQueryPdu::getRequestedPerimeterPoints() const
+const std::vector<DIS::Point>& MinefieldQueryPdu::getRequestedPerimeterPoints() const
 {
     return _requestedPerimeterPoints;
 }
 
-void MinefieldQueryPdu::setRequestedPerimeterPoints(const std::vector<Point>& pX)
+void MinefieldQueryPdu::setRequestedPerimeterPoints(const std::vector<DIS::Point>& pX)
 {
      _requestedPerimeterPoints = pX;
 }
@@ -151,7 +151,7 @@ void MinefieldQueryPdu::marshal(DataStream& dataStream) const
 
      for(size_t idx = 0; idx < _requestedPerimeterPoints.size(); idx++)
      {
-        Point x = _requestedPerimeterPoints[idx];
+        DIS::Point x = _requestedPerimeterPoints[idx];
         x.marshal(dataStream);
      }
 
@@ -179,7 +179,7 @@ void MinefieldQueryPdu::unmarshal(DataStream& dataStream)
      _requestedPerimeterPoints.clear();
      for(size_t idx = 0; idx < _numberOfPerimeterPoints; idx++)
      {
-        Point x;
+        DIS::Point x;
         x.unmarshal(dataStream);
         _requestedPerimeterPoints.push_back(x);
      }
@@ -238,7 +238,7 @@ int MinefieldQueryPdu::getMarshalledSize() const
 
    for(unsigned long long idx=0; idx < _requestedPerimeterPoints.size(); idx++)
    {
-        Point listElement = _requestedPerimeterPoints[idx];
+        DIS::Point listElement = _requestedPerimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 

--- a/Source/ThirdParty/include/dis6/MinefieldStatePdu.cpp
+++ b/Source/ThirdParty/include/dis6/MinefieldStatePdu.cpp
@@ -134,17 +134,17 @@ void MinefieldStatePdu::setProtocolMode(unsigned short pX)
     _protocolMode = pX;
 }
 
-std::vector<Point>& MinefieldStatePdu::getPerimeterPoints() 
+std::vector<DIS::Point>& MinefieldStatePdu::getPerimeterPoints() 
 {
     return _perimeterPoints;
 }
 
-const std::vector<Point>& MinefieldStatePdu::getPerimeterPoints() const
+const std::vector<DIS::Point>& MinefieldStatePdu::getPerimeterPoints() const
 {
     return _perimeterPoints;
 }
 
-void MinefieldStatePdu::setPerimeterPoints(const std::vector<Point>& pX)
+void MinefieldStatePdu::setPerimeterPoints(const std::vector<DIS::Point>& pX)
 {
      _perimeterPoints = pX;
 }
@@ -180,7 +180,7 @@ void MinefieldStatePdu::marshal(DataStream& dataStream) const
 
      for(size_t idx = 0; idx < _perimeterPoints.size(); idx++)
      {
-        Point x = _perimeterPoints[idx];
+        DIS::Point x = _perimeterPoints[idx];
         x.marshal(dataStream);
      }
 
@@ -210,7 +210,7 @@ void MinefieldStatePdu::unmarshal(DataStream& dataStream)
      _perimeterPoints.clear();
      for(size_t idx = 0; idx < _numberOfPerimeterPoints; idx++)
      {
-        Point x;
+        DIS::Point x;
         x.unmarshal(dataStream);
         _perimeterPoints.push_back(x);
      }
@@ -273,7 +273,7 @@ int MinefieldStatePdu::getMarshalledSize() const
 
    for(unsigned long long idx=0; idx < _perimeterPoints.size(); idx++)
    {
-        Point listElement = _perimeterPoints[idx];
+        DIS::Point listElement = _perimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 

--- a/Source/ThirdParty/include/dis6/Point.cpp
+++ b/Source/ThirdParty/include/dis6/Point.cpp
@@ -3,50 +3,50 @@
 using namespace DIS;
 
 
-Point::Point():
+DIS::Point::Point():
    _x(0.0), 
    _y(0.0)
 {
 }
 
-Point::~Point()
+DIS::Point::~Point()
 {
 }
 
-float Point::getX() const
+float DIS::Point::getX() const
 {
     return _x;
 }
 
-void Point::setX(float pX)
+void DIS::Point::setX(float pX)
 {
     _x = pX;
 }
 
-float Point::getY() const
+float DIS::Point::getY() const
 {
     return _y;
 }
 
-void Point::setY(float pX)
+void DIS::Point::setY(float pX)
 {
     _y = pX;
 }
 
-void Point::marshal(DataStream& dataStream) const
+void DIS::Point::marshal(DataStream& dataStream) const
 {
     dataStream << _x;
     dataStream << _y;
 }
 
-void Point::unmarshal(DataStream& dataStream)
+void DIS::Point::unmarshal(DataStream& dataStream)
 {
     dataStream >> _x;
     dataStream >> _y;
 }
 
 
-bool Point::operator ==(const Point& rhs) const
+bool DIS::Point::operator ==(const DIS::Point& rhs) const
  {
      bool ivarsEqual = true;
 
@@ -56,7 +56,7 @@ bool Point::operator ==(const Point& rhs) const
     return ivarsEqual;
  }
 
-int Point::getMarshalledSize() const
+int DIS::Point::getMarshalledSize() const
 {
    int marshalSize = 0;
 

--- a/Source/ThirdParty/include/dis6/opendis6_export.h
+++ b/Source/ThirdParty/include/dis6/opendis6_export.h
@@ -2,6 +2,20 @@
 #ifndef OPENDIS6_EXPORT_H
 #define OPENDIS6_EXPORT_H
 
+#if defined(_MSC_VER)
+#  define OPENDIS6_DECL_EXPORT __declspec(dllexport)
+#  define OPENDIS6_DECL_IMPORT __declspec(dllimport)
+#  define OPENDIS6_DECL_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__) || defined(__clang__)
+#  define OPENDIS6_DECL_EXPORT __attribute__((visibility("default")))
+#  define OPENDIS6_DECL_IMPORT __attribute__((visibility("default")))
+#  define OPENDIS6_DECL_DEPRECATED __attribute__((deprecated))
+#else
+#  define OPENDIS6_DECL_EXPORT
+#  define OPENDIS6_DECL_IMPORT
+#  define OPENDIS6_DECL_DEPRECATED
+#endif
+
 #ifdef OPENDIS6_STATIC_DEFINE
 #  define OPENDIS6_EXPORT
 #  define OPENDIS6_NO_EXPORT
@@ -9,10 +23,10 @@
 #  ifndef OPENDIS6_EXPORT
 #    ifdef OpenDIS6_EXPORTS
         /* We are building this library */
-#      define OPENDIS6_EXPORT __declspec(dllexport)
+#      define OPENDIS6_EXPORT OPENDIS6_DECL_EXPORT
 #    else
         /* We are using this library */
-#      define OPENDIS6_EXPORT __declspec(dllimport)
+#      define OPENDIS6_EXPORT OPENDIS6_DECL_IMPORT
 #    endif
 #  endif
 
@@ -22,7 +36,7 @@
 #endif
 
 #ifndef OPENDIS6_DEPRECATED
-#  define OPENDIS6_DEPRECATED __declspec(deprecated)
+#  define OPENDIS6_DEPRECATED OPENDIS6_DECL_DEPRECATED
 #endif
 
 #ifndef OPENDIS6_DEPRECATED_EXPORT

--- a/Source/ThirdParty/include/dis6/utils/DataStream.h
+++ b/Source/ThirdParty/include/dis6/utils/DataStream.h
@@ -8,7 +8,7 @@
 // the class member, DataStream::BufferType is causing warnign 4251.
 // disable it until a proper fix is found, as instructed from the enlightening article:
 // http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
-#if _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning( push )
 #pragma warning( disable : 4251 )
 #endif
@@ -146,7 +146,7 @@ namespace DIS
    };
 }
 
-#if _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning( pop )
 #endif
 

--- a/Source/ThirdParty/include/dis7/opendis7_export.h
+++ b/Source/ThirdParty/include/dis7/opendis7_export.h
@@ -2,6 +2,20 @@
 #ifndef OPENDIS7_EXPORT_H
 #define OPENDIS7_EXPORT_H
 
+#if defined(_MSC_VER)
+#  define OPENDIS7_DECL_EXPORT __declspec(dllexport)
+#  define OPENDIS7_DECL_IMPORT __declspec(dllimport)
+#  define OPENDIS7_DECL_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__) || defined(__clang__)
+#  define OPENDIS7_DECL_EXPORT __attribute__((visibility("default")))
+#  define OPENDIS7_DECL_IMPORT __attribute__((visibility("default")))
+#  define OPENDIS7_DECL_DEPRECATED __attribute__((deprecated))
+#else
+#  define OPENDIS7_DECL_EXPORT
+#  define OPENDIS7_DECL_IMPORT
+#  define OPENDIS7_DECL_DEPRECATED
+#endif
+
 #ifdef OPENDIS7_STATIC_DEFINE
 #  define OPENDIS7_EXPORT
 #  define OPENDIS7_NO_EXPORT
@@ -9,10 +23,10 @@
 #  ifndef OPENDIS7_EXPORT
 #    ifdef OpenDIS7_EXPORTS
         /* We are building this library */
-#      define OPENDIS7_EXPORT __declspec(dllexport)
+#      define OPENDIS7_EXPORT OPENDIS7_DECL_EXPORT
 #    else
         /* We are using this library */
-#      define OPENDIS7_EXPORT __declspec(dllimport)
+#      define OPENDIS7_EXPORT OPENDIS7_DECL_IMPORT
 #    endif
 #  endif
 
@@ -22,7 +36,7 @@
 #endif
 
 #ifndef OPENDIS7_DEPRECATED
-#  define OPENDIS7_DEPRECATED __declspec(deprecated)
+#  define OPENDIS7_DEPRECATED OPENDIS7_DECL_DEPRECATED
 #endif
 
 #ifndef OPENDIS7_DEPRECATED_EXPORT

--- a/Source/ThirdParty/include/dis7/utils/DataStream.h
+++ b/Source/ThirdParty/include/dis7/utils/DataStream.h
@@ -8,7 +8,7 @@
 // the class member, DataStream::BufferType is causing warnign 4251.
 // disable it until a proper fix is found, as instructed from the enlightening article:
 // http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
-#if _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning( push )
 #pragma warning( disable : 4251 )
 #endif
@@ -146,7 +146,7 @@ namespace DIS
    };
 }
 
-#if _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning( pop )
 #endif
 


### PR DESCRIPTION
Changes included:

- update plugin/module configuration for Unreal Engine 5.7
- add explicit Win64 and macOS platform support in build and plugin metadata
- add Blueprint-accessible runtime platform helpers for Windows/macOS checks
- apply runtime compatibility fixes across DIS runtime components
- include networking and socket handling improvements for cross-platform behavior
- include supporting fixes in bundled OpenDIS/third-party sources required for successful build/runtime behavior on current toolchains